### PR TITLE
add token based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ def handle_message(channel_id, sender_id, msg_id, thread_id, msg, qualifier):
     print(msg)
 
 
-async def main(address, username, password):
+async def main(address, username, token):
     while True:
         try:
             rc = RocketChat()

--- a/README.md
+++ b/README.md
@@ -51,6 +51,43 @@ async def main(address, username, password):
 # Side note: Don't forget to use the wss:// scheme when TLS is used.
 asyncio.run(main('ws://localhost:3000/websocket', 'username', 'password'))
 ```
+## Example authentication with token
+
+```python
+import asyncio
+import random
+from rocketchat_async import RocketChat
+
+
+def handle_message(channel_id, sender_id, msg_id, thread_id, msg, qualifier):
+    """Simply print the message that arrived."""
+    print(msg)
+
+
+async def main(address, username, password):
+    while True:
+        try:
+            rc = RocketChat()
+            await rc.resume(address, username, token)
+
+            # A possible workflow consists of two steps:
+            #
+            # 1. Set up the desired callbacks...
+            for channel_id, channel_type in await rc.get_channels():
+                await rc.subscribe_to_channel_messages(channel_id,
+                                                       handle_message)
+            # 2. ...and then simply wait for the registered events.
+            await rc.run_forever()
+        except (RocketChat.ConnectionClosed,
+                RocketChat.ConnectCallFailed) as e:
+            print(f'Connection failed: {e}. Waiting a few seconds...')
+            await asyncio.sleep(random.uniform(4, 8))
+            print('Reconnecting...')
+
+
+# Side note: Don't forget to use the wss:// scheme when TLS is used.
+asyncio.run(main('ws://localhost:3000/websocket', 'username', 'token'))
+```
 
 ## API Overview
 

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -26,6 +26,34 @@ class Connect(RealtimeRequest):
         await dispatcher.call_method(cls.REQUEST_MSG)
 
 
+class Resume(RealtimeRequest):
+    """Log in to the service."""
+
+    @staticmethod
+    def _get_request_msg(msg_id, token):
+        return {
+            "msg": "method",
+            "method": "login",
+            "id": msg_id,
+            "params": [
+                {
+                    "resume": token,
+                }
+            ]
+        }
+
+    @staticmethod
+    def _parse(response):
+        return response['result']['id'], 
+
+    @classmethod
+    async def call(cls, dispatcher, token):
+        msg_id = cls._get_new_id()
+        msg = cls._get_request_msg(msg_id, token)
+        response = await dispatcher.call_method(msg, msg_id)
+        return cls._parse(response)
+
+
 class Login(RealtimeRequest):
     """Log in to the service."""
 


### PR DESCRIPTION
```
async def main(address, username, token):
    while True:
        try:
            rc = RocketChat()
            await rc.resume(address,username, token)

            # A possible workflow consists of two steps:
            #
            # 1. Set up the desired callbacks...
            for channel_id, channel_type in await rc.get_channels():
            # 2. ...and then simply wait for the registered events.
            await rc.run_forever()

        except (RocketChat.ConnectionClosed,
                RocketChat.ConnectCallFailed) as e:
            print(f'Connection failed: {e}. Waiting a few seconds...')
            await asyncio.sleep(random.uniform(4, 8))
            print('Reconnecting...')


asyncio.run(main('websocket', 'username', 'token'))
```