### PR TITLE
Add `re_received` Flag to Enhance Thread Reply Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from rocketchat_async import RocketChat
 
 
 def handle_message(channel_id, sender_id, msg_id, thread_id, msg, qualifier,
-                   unread):
+                   unread, re_received):
     """Simply print the message that arrived."""
     print(msg)
 
@@ -84,11 +84,13 @@ Send the "typing" event to a channel.
 
 Subscribe to all messages in the given channel. Returns the subscription ID.
 
-The provided callback should accept six arguments: `channel_id`,
-`sender_id`, `msg_id`, `thread_id`, `msg_text` and
-`msg_qualifier`. The qualifier can help to determine if e.g. the
+The provided callback should accept eight arguments: `channel_id`,
+`sender_id`, `msg_id`, `thread_id`, `msg_text`, `msg_qualifier`
+ and `re_received`. The qualifier can help to determine if e.g. the
 message is a system message about the user being removed from
-the channel.
+the channel.  The `re_received` flag assists in distinguishing 
+whether the message has been received again as a result of 
+thread replies, or if it is a new message post.
 
 #### `RocketChat.subscribe_to_channel_changes(callback)`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from rocketchat_async import RocketChat
 
 
 def handle_message(channel_id, sender_id, msg_id, thread_id, msg, qualifier,
-                   unread, re_received):
+                   unread, repeated):
     """Simply print the message that arrived."""
     print(msg)
 
@@ -86,9 +86,9 @@ Subscribe to all messages in the given channel. Returns the subscription ID.
 
 The provided callback should accept eight arguments: `channel_id`,
 `sender_id`, `msg_id`, `thread_id`, `msg_text`, `msg_qualifier`
- and `re_received`. The qualifier can help to determine if e.g. the
+ and `repeated`. The qualifier can help to determine if e.g. the
 message is a system message about the user being removed from
-the channel.  The `re_received` flag assists in distinguishing 
+the channel.  The `repeated` flag assists in distinguishing 
 whether the message has been received again as a result of 
 thread replies, or if it is a new message post.
 

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -215,9 +215,9 @@ class SubscribeToChannelMessages(RealtimeRequest):
             msg = event['msg']
             qualifier = event.get('t')
             unread = event.get('unread', False)
-            re_received = bool(event.get('replies'))
+            repeated = bool(event.get('replies'))
             return callback(channel_id, sender_id, msg_id, thread_id, msg,
-                            qualifier, unread, re_received)
+                            qualifier, unread, repeated)
         return fn
 
     @classmethod

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -215,8 +215,9 @@ class SubscribeToChannelMessages(RealtimeRequest):
             msg = event['msg']
             qualifier = event.get('t')
             unread = event.get('unread', False)
+            re_received = bool(event.get('replies'))
             return callback(channel_id, sender_id, msg_id, thread_id, msg,
-                            qualifier, unread)
+                            qualifier, unread, re_received)
         return fn
 
     @classmethod


### PR DESCRIPTION
### Overview
This PR introduces a new boolean flag, re_received, to the callback function of the SubscribeToChannelMessages class, aiming to improve the detection of messages that are received again as a part of thread replies. This enhancement addresses the need to distinguish between new message posts and re-received messages due to activity in their associated threads.

### Background
In practice, I've encountered a recurring issue where the new messages in a thread trigger notifications, and the thread's initial message gets re-sent every time. This redundancy has been problematic, cluttering the message flow and complicating message handling logic. To resolve this, a clear way to identify re-received messages became necessary. Hence, introducing the re-received flag aims to tackle this issue precisely by allowing for the differentiation of messages and ensuring that only relevant messages are processed further.