### PR TITLE
Enable send_typing_event for threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Send a text message to a channel.
 
 Send a reaction to a specific message.
 
-#### `RocketChat.send_typing_event(channel_id)`
+#### `RocketChat.send_typing_event(channel_id, thread_id=None)`
 
-Send the "typing" event to a channel.
+Send the "typing" event to a channel or to a specified thread within that channel.
 
 #### `RocketChat.subscribe_to_channel_messages(channel_id, callback)`
 

--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -96,9 +96,9 @@ class RocketChat:
         """Send a reaction to a specific message."""
         await SendReaction.call(self._dispatcher, orig_msg_id, emoji)
 
-    async def send_typing_event(self, channel_id):
+    async def send_typing_event(self, channel_id, thread_id=None):
         """Send the `typing` event to a channel."""
-        await SendTypingEvent.call(self._dispatcher, channel_id, self.username)
+        await SendTypingEvent.call(self._dispatcher, channel_id, self.username, thread_id)
 
     async def subscribe_to_channel_messages(self, channel_id, callback):
         """

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -167,8 +167,8 @@ class SendTypingEvent(RealtimeRequest):
     """Send the `typing` event to a channel."""
 
     @staticmethod
-    def _get_request_msg(msg_id, channel_id, username):
-        return {
+    def _get_request_msg(msg_id, channel_id, username, thread_id=None):
+        msg = {
             "msg": "method",
             "method": "stream-notify-room",
             "id": msg_id,
@@ -179,11 +179,14 @@ class SendTypingEvent(RealtimeRequest):
                 {}
             ]
         }
+        if(thread_id):
+            msg["params"][-1]["tmid"] = thread_id
+        return msg
 
     @classmethod
-    async def call(cls, dispatcher, channel_id, username):
+    async def call(cls, dispatcher, channel_id, username, thread_id=None):
         msg_id = cls._get_new_id()
-        msg = cls._get_request_msg(msg_id, channel_id, username)
+        msg = cls._get_request_msg(msg_id, channel_id, username, thread_id)
         await dispatcher.call_method(msg, msg_id)
 
 


### PR DESCRIPTION
## Summary

This pull request implements an enhancement to the `send_typing_event` function, allowing it to send typing notifications not only to Rocket.Chat channels but also to specific threads within those channels. 

## Purpose

The current implementation of `send_typing_event` is limited to notifying about typing events at the channel level. For some applications, such as chatbots replying within threads, it is desirable to indicate typing events at the thread level. This update enables an optional `thread_id` parameter to be passed along with the `channel_id` to `send_typing_event`. If a `thread_id` is provided, the typing event will be directed to the specified thread. The behavior of the function without the `thread_id` remains unchanged.

## Implementation Details

The change involves minor modifications to:
- The `send_typing_event` method in `core.py`, where I have added an optional `thread_id` parameter.
- The `SendTypingEvent` class in `methods.py`, which now constructs the request payload with the `thread_id` if it is provided.

Backward compatibility has been maintained, ensuring that existing codebases using the `send_typing_event` function will continue to work as they did previously, without specifying a `thread_id`.

## Testing & Compatibility

Testing was conducted on Rocket.Chat version 6.7.0, where the following behaviors were confirmed:
- Typing events are correctly sent to channels when `thread_id` is not provided.
- Typing events are correctly sent to the specified thread when `thread_id` is provided.
- The absence of `thread_id` maintains the existing functionality without any adverse effects.

---
Your review and feedback on this addition would be greatly appreciated.

Best regards,