### PR TITLE
Update/subscribe to channel changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ thread replies, or if it is a new message post.
 
 Subscribe to all changes in channels. Returns the subscription ID.
 
-The provided callback should accept two arguments: `channel_id`
-and `channel_qualifier`. The qualifier helps to determine e.g.
+The provided callback should accept four arguments: `channel_id`
+, `channel_qualifier` , `event_type`, and `info`. The qualifier helps to determine e.g.
 if it's a direct message or a normal room.
+The event_type indicates the kind of event that occurred.
+For instance, the event_type can be "joined", "file_added", or "other".
 
 #### `RocketChat.unsubscribe(subscription_id)`
 

--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -122,6 +122,14 @@ class RocketChat:
                                                       self.user_id, callback)
         return sub_id
 
+    async def subscribe_to_workspace_channel_activity(self, user_id, callback):
+    """
+    Subscribe to changes in channel membership.
+
+    Returns the subscription ID.
+    """
+    return await SubscribeToWorkspaceChannelActivity.call(self._dispatcher, user_id, callback)
+
     async def unsubscribe(self, subscription_id):
         """Cancel a subscription."""
         await Unsubscribe.call(self._dispatcher, subscription_id)

--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -4,7 +4,7 @@ import websockets
 from rocketchat_async.dispatcher import Dispatcher
 from rocketchat_async.methods import Connect, Login, Resume, GetChannels, SendMessage,\
         SendReaction, SendTypingEvent, SubscribeToChannelMessages,\
-        SubscribeToChannelChanges, SubscribeToWorkspaceChannelActivity, Unsubscribe
+        SubscribeToChannelChanges, Unsubscribe, SubscribeToUserActivity
 
 
 class RocketChat:
@@ -122,14 +122,15 @@ class RocketChat:
                                                       self.user_id, callback)
         return sub_id
 
-    async def subscribe_to_workspace_channel_activity(self, callback):
-        """
-        Subscribe to changes in channel membership.
-
-        Returns the subscription ID.
-        """
-        return await SubscribeToWorkspaceChannelActivity.call(self._dispatcher, self.user_id, callback)
-
     async def unsubscribe(self, subscription_id):
         """Cancel a subscription."""
         await Unsubscribe.call(self._dispatcher, subscription_id)
+
+    async def subscribe_to_user_activity(self, callback):
+        """
+        Subscribe to user login and logout activities.
+
+        Returns the subscription ID.
+        """
+        sub_id = await SubscribeToUserActivity.call(self._dispatcher, callback)
+        return sub_id

--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -4,7 +4,7 @@ import websockets
 from rocketchat_async.dispatcher import Dispatcher
 from rocketchat_async.methods import Connect, Login, Resume, GetChannels, SendMessage,\
         SendReaction, SendTypingEvent, SubscribeToChannelMessages,\
-        SubscribeToChannelChanges, Unsubscribe, SubscribeToUserActivity
+        SubscribeToChannelChanges, Unsubscribe
 
 
 class RocketChat:
@@ -125,12 +125,3 @@ class RocketChat:
     async def unsubscribe(self, subscription_id):
         """Cancel a subscription."""
         await Unsubscribe.call(self._dispatcher, subscription_id)
-
-    async def subscribe_to_user_activity(self, callback):
-        """
-        Subscribe to user login and logout activities.
-
-        Returns the subscription ID.
-        """
-        sub_id = await SubscribeToUserActivity.call(self._dispatcher, callback)
-        return sub_id

--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -4,7 +4,7 @@ import websockets
 from rocketchat_async.dispatcher import Dispatcher
 from rocketchat_async.methods import Connect, Login, Resume, GetChannels, SendMessage,\
         SendReaction, SendTypingEvent, SubscribeToChannelMessages,\
-        SubscribeToChannelChanges, Unsubscribe
+        SubscribeToChannelChanges, SubscribeToWorkspaceChannelActivity, Unsubscribe
 
 
 class RocketChat:
@@ -122,13 +122,13 @@ class RocketChat:
                                                       self.user_id, callback)
         return sub_id
 
-    async def subscribe_to_workspace_channel_activity(self, user_id, callback):
-    """
-    Subscribe to changes in channel membership.
+    async def subscribe_to_workspace_channel_activity(self, callback):
+        """
+        Subscribe to changes in channel membership.
 
-    Returns the subscription ID.
-    """
-    return await SubscribeToWorkspaceChannelActivity.call(self._dispatcher, user_id, callback)
+        Returns the subscription ID.
+        """
+        return await SubscribeToWorkspaceChannelActivity.call(self._dispatcher, self.user_id, callback)
 
     async def unsubscribe(self, subscription_id):
         """Cancel a subscription."""

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -250,13 +250,20 @@ class SubscribeToChannelChanges(RealtimeRequest):
     @staticmethod
     def _wrap(callback):
         def fn(msg):
+            print(msg)
             payload = msg['fields']['args']
+            info = payload[1]
             if payload[0] == 'removed':
                 return  # Nothing else to do - channel has just been deleted.
-            event_type = payload[0]
+            elif payload[0] == 'inserted':
+                event_type = 'joined'
+            elif 'file' in payload[1]["lastMessage"]:
+                event_type = 'file_added'
+            else:
+                event_type = 'other'
             channel_id = payload[1]['_id']
             channel_type = payload[1]['t']
-            return callback(channel_id, channel_type, event_type)
+            return callback(channel_id, channel_type, event_type, info)
         return fn
 
     @classmethod

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -250,7 +250,6 @@ class SubscribeToChannelChanges(RealtimeRequest):
     @staticmethod
     def _wrap(callback):
         def fn(msg):
-            print(msg)
             payload = msg['fields']['args']
             info = payload[1]
             if payload[0] == 'removed':

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -131,12 +131,20 @@ class SubscribeToWorkspaceChannelActivity(RealtimeRequest):
     def _wrap(callback):
         def fn(msg):
             payload = msg['fields']['args']
+            print("======== GET PAYLOAD ========")
+            print(payload[0])
+            print("---")
+            print(payload[1])
+            print("=======")
             if payload[0] == 'removed':
                 channel_id = payload[1]['_id']
-                callback(channel_id, 'removed')
+                callback(channel_id, 'removed') #currently not working
             elif payload[0] == 'inserted':
                 channel_id = payload[1]['_id']
                 callback(channel_id, 'inserted')
+            else:
+                channel_id = payload[1]['_id']
+                callback(channel_id, payload[0])
         return fn
 
     @classmethod

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -282,33 +282,3 @@ class Unsubscribe(RealtimeRequest):
     async def call(cls, dispatcher, subscription_id):
         msg = cls._get_request_msg(subscription_id)
         await dispatcher.call_method(msg)
-
-class SubscribeToUserActivity(RealtimeRequest):
-    """Subscribe to user login and logout activities."""
-
-    @staticmethod
-    def _get_request_msg(msg_id):
-        return {
-            "msg": "sub",
-            "id": msg_id,
-            "name": "stream-notify-logged",
-            "params": [
-                "user-status",
-                False
-            ]
-        }
-
-    @staticmethod
-    def _wrap(callback):
-        def fn(msg):
-            event_type = msg['fields']['eventName']
-            user_status = msg['fields']['args'][0]
-            callback(event_type, user_status)
-        return fn
-
-    @classmethod
-    async def call(cls, dispatcher, callback):
-        msg_id = cls._get_new_id()
-        msg = cls._get_request_msg(msg_id)
-        await dispatcher.create_subscription(msg, msg_id, cls._wrap(callback))
-        return msg_id


### PR DESCRIPTION
Related issue #10 


I have updated the subscribe_to_channel_changes method to detect when the user joins a new channel or DM and when a file is uploaded to a channel they are part of. However, it does not detect other events such as being kicked from a channel or other users joining.

Additionally, there is a known issue where the method uses lastMessage for detection, which results in multiple file_added events being detected if the lastMessage involves a file upload.

I acknowledge this method is not ideal, but it is an attempt to make it more useful.