### PR TITLE
Add "raw" variants of some methods

### DIFF
--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -4,7 +4,7 @@ import websockets
 from rocketchat_async.dispatcher import Dispatcher
 from rocketchat_async.methods import Connect, Login, Resume, GetChannels, GetChannelsRaw,\
         SendMessage, SendReaction, SendTypingEvent, SubscribeToChannelMessages,\
-        SubscribeToChannelChanges, Unsubscribe
+        SubscribeToChannelMessagesRaw, SubscribeToChannelChanges, Unsubscribe
 
 
 class RocketChat:
@@ -118,6 +118,19 @@ class RocketChat:
 
         """
         sub_id = await SubscribeToChannelMessages.call(self._dispatcher,
+                                                       channel_id, callback)
+        return sub_id
+
+    async def subscribe_to_channel_messages_raw(self, channel_id, callback):
+        """
+        Subscribe to all messages in the given channel.
+
+        The callback is passed the full message object as provided by the API.
+
+        Returns the subscription ID.
+
+        """
+        sub_id = await SubscribeToChannelMessagesRaw.call(self._dispatcher,
                                                        channel_id, callback)
         return sub_id
 

--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -2,8 +2,8 @@ import asyncio
 import websockets
 
 from rocketchat_async.dispatcher import Dispatcher
-from rocketchat_async.methods import Connect, Login, Resume, GetChannels, SendMessage,\
-        SendReaction, SendTypingEvent, SubscribeToChannelMessages,\
+from rocketchat_async.methods import Connect, Login, Resume, GetChannels, GetChannelsRaw,\
+        SendMessage, SendReaction, SendTypingEvent, SubscribeToChannelMessages,\
         SubscribeToChannelChanges, Unsubscribe
 
 
@@ -85,8 +85,18 @@ class RocketChat:
     # --> Public API methods start here. <--
 
     async def get_channels(self):
-        """Get a list of channels user is currently member of."""
+        """Get a list of channels user is currently member of.
+
+        Returns a list of (channel id, channel type) pairs.
+        """
         return await GetChannels.call(self._dispatcher)
+
+    async def get_channels_raw(self):
+        """Get a list of channels user is currently member of.
+
+        Returns a list of channel objects.
+        """
+        return await GetChannelsRaw.call(self._dispatcher)
 
     async def send_message(self, text, channel_id, thread_id=None):
         """Send a text message to a channel."""

--- a/rocketchat_async/methods.py
+++ b/rocketchat_async/methods.py
@@ -87,8 +87,11 @@ class Login(RealtimeRequest):
         return cls._parse(response)
 
 
-class GetChannels(RealtimeRequest):
-    """Get a list of channels user is currently member of."""
+class GetChannelsRaw(RealtimeRequest):
+    """Get a list of channels user is currently member of.
+
+    Returns the complete channel objects.
+    """
 
     @staticmethod
     def _get_request_msg(msg_id):
@@ -101,8 +104,7 @@ class GetChannels(RealtimeRequest):
 
     @staticmethod
     def _parse(response):
-        # Return channel IDs and channel types.
-        return [(r['_id'], r['t']) for r in response['result']]
+        return response['result']
 
     @classmethod
     async def call(cls, dispatcher):
@@ -110,6 +112,18 @@ class GetChannels(RealtimeRequest):
         msg = cls._get_request_msg(msg_id)
         response = await dispatcher.call_method(msg, msg_id)
         return cls._parse(response)
+
+
+class GetChannels(GetChannelsRaw):
+    """Get a list of channels user is currently member of.
+
+    Returns a list of (channel id, channel type) pairs.
+    """
+
+    @classmethod
+    def _parse(cls, response):
+        # Return channel IDs and channel types.
+        return [(r['_id'], r['t']) for r in super()._parse(response)]
 
 
 class SendMessage(RealtimeRequest):


### PR DESCRIPTION
I'm trying to port an internal project from the discontinued `rocketbot` project to this library and ran into some missing information that is provided by the RocketChat API but discarded by the library. To provide this information without breaking API, this PR adds "raw" variants of the `get_channels` and `subscribe_to_channel_messages` methods.

To avoid code duplication, the existing implementations are rebased on the new "raw" variants.