### PR TITLE
Ignore non-standard messages from server

### DIFF
--- a/rocketchat_async/core.py
+++ b/rocketchat_async/core.py
@@ -17,10 +17,10 @@ class RocketChat:
     class ConnectCallFailed(Exception):
         pass
 
-    def __init__(self):
+    def __init__(self, verbose=False):
         self.user_id = None
         self.username = None
-        self._dispatcher = Dispatcher(verbose=False)
+        self._dispatcher = Dispatcher(verbose)
 
     async def start(self, address, username, password):
         ws_connected = asyncio.get_event_loop().create_future()

--- a/rocketchat_async/dispatcher.py
+++ b/rocketchat_async/dispatcher.py
@@ -52,6 +52,8 @@ class Dispatcher:
         if self._verbose:
             print(f'Incoming: {msg}')
         parsed = json.loads(msg)
+        if 'msg' not in parsed:
+            return # most likely a server introduction, no awaiters for this one
         if parsed['msg'] == 'result':
             msg_id = parsed['id']
             if msg_id in self._futures:


### PR DESCRIPTION
I found out that in some environments (e.g. mine :wink: ) server can send out an unsolicited info message (in the form `{"server_id":"0"}`) right after websockets connection is established.
Current version of rocketchat-async tries to process it as a response to initial "connect" message, which obviously fails.
Unfortunately it makes the whole connection process hang indefinitely, since there are no awaiters for "connected" message, thus the exception is not propagated anywhere.

Proposed change simply ignores all incoming JSON messages that do not contain "msg" field.
Additionally I've exposed `verbose` parameter as a part of public API to allow to activate it without modifying the library code.